### PR TITLE
sensorservice: Fix orientation sensor for HAL's missing rotation vect…

### DIFF
--- a/services/sensorservice/SensorService.cpp
+++ b/services/sensorservice/SensorService.cpp
@@ -191,7 +191,7 @@ void SensorService::onFirstRef() {
                 // available in the HAL
                 bool needRotationVector =
                         (virtualSensorsNeeds & (1<<SENSOR_TYPE_ROTATION_VECTOR)) != 0;
-                bool needOrientation = !needRotationVector && orientationIndex == -1;
+                bool needOrientation = orientationIndex == -1;
 
                 registerSensor(new RotationVectorSensor(), !needRotationVector, true);
                 registerSensor(new OrientationSensor(), !needOrientation, true);


### PR DESCRIPTION
…or sensor

Some HAL's doesn't have a hardware rotation sensor, and with the
current check, the orientation sensor depends on it before it's
available to the system. Remove the dependency.

Fixes compass on some devices.

Change-Id: I58f746b3dee1eb5a637b21efb8fecddc10c31e3a